### PR TITLE
chore: promote xl-go-devops-training to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-dtilc-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-dtilc-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-kbyva
+  name: jx-verify-gc-jobs-dtilc
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-staging
+  namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-mqjfs-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-mqjfs-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-ehhdr
+  name: jx-verify-gc-jobs-mqjfs
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-qathq
+    app: jx-verify-gc-jobs-e4zeu
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/xl-go-devops-training/xl-go-devops-training-ingress.yaml
+++ b/config-root/namespaces/jx-production/xl-go-devops-training/xl-go-devops-training-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: xl-go-devops-training/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'xl-go-devops-training'
+  name: xl-go-devops-training
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: xl-go-devops-training
+                port:
+                  number: 80
+      host: xl-go-devops-training-jx-production.35.186.144.18.nip.io

--- a/config-root/namespaces/jx-production/xl-go-devops-training/xl-go-devops-training-svc.yaml
+++ b/config-root/namespaces/jx-production/xl-go-devops-training/xl-go-devops-training-svc.yaml
@@ -1,0 +1,20 @@
+# Source: xl-go-devops-training/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: xl-go-devops-training
+  labels:
+    chart: "xl-go-devops-training-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'xl-go-devops-training'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: xl-go-devops-training-xl-go-devops-training

--- a/config-root/namespaces/jx-production/xl-go-devops-training/xl-go-devops-training-xl-go-devops-training-deploy.yaml
+++ b/config-root/namespaces/jx-production/xl-go-devops-training/xl-go-devops-training-xl-go-devops-training-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: xl-go-devops-training/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: xl-go-devops-training-xl-go-devops-training
+  labels:
+    draft: draft-app
+    chart: "xl-go-devops-training-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'xl-go-devops-training'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: xl-go-devops-training-xl-go-devops-training
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: xl-go-devops-training-xl-go-devops-training
+    spec:
+      serviceAccountName: xl-go-devops-training-xl-go-devops-training
+      containers:
+        - name: xl-go-devops-training
+          image: "gcr.io/xl-devops/xl-go-devops-training:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/xl-go-devops-training/xl-go-devops-training-xl-go-devops-training-sa.yaml
+++ b/config-root/namespaces/jx-production/xl-go-devops-training/xl-go-devops-training-xl-go-devops-training-sa.yaml
@@ -1,0 +1,10 @@
+# Source: xl-go-devops-training/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: xl-go-devops-training-xl-go-devops-training
+  annotations:
+    meta.helm.sh/release-name: 'xl-go-devops-training'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-1rjpx-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-1rjpx-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-2esdo
+  name: jx-verify-gc-jobs-1rjpx
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-production
+  namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-3zi6l-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-3zi6l-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-jxx6f
+  name: jx-verify-gc-jobs-3zi6l
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-rokik
+    app: jx-verify-gc-jobs-dxh4l
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,12 @@
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> xl-go-devops-training </a></td>
+	      <td>0.0.1</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -16,6 +16,18 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-production/jx-verify
+  - apiVersion: v1
+    appVersion: 0.0.1
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-03-14T15:23:48Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-03-14T15:23:48Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=xl-devops&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fjx3-dev-cluster%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Fxl-go-devops-training&dateRangeUnbound=both
+    name: xl-go-devops-training
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.35.186.144.18.nip.io
+    resourcePath: config-root/namespaces/jx-production/xl-go-devops-training
+    version: 0.0.1
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jxgh
   url: https://jenkins-x-charts.github.io/repo
+- name: dev
+  url: http://chartmuseum-jx.35.186.144.18.nip.io
 releases:
 - chart: jxgh/jx-verify
   name: jx-verify
   namespace: jx-production
   values:
   - jx-values.yaml
+- chart: dev/xl-go-devops-training
+  version: 0.0.1
+  name: xl-go-devops-training
+  namespace: jx-production
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.1
   name: xl-go-devops-training
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote xl-go-devops-training to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
