### PR TITLE
chore: promote xl-go-devops-training to version 0.0.4

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/xl-go-devops-training
-  version: 0.0.3
+  version: 0.0.4
   name: xl-go-devops-training
   namespace: jx-production
   values:


### PR DESCRIPTION
chore: promote xl-go-devops-training to version 0.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
